### PR TITLE
Unsupported special dependency :python3

### DIFF
--- a/videomorph.rb
+++ b/videomorph.rb
@@ -10,9 +10,9 @@ class VideoMorph < Formula
   # TODO: If you're submitting an existing package, make sure you include your
   #       bottle block here.
 
-  depends_on :python3
-  depends_on :ffmpeg
-  depends_on :pyqt
+  depends_on "python"
+  depends_on "ffmpeg"
+  depends_on "pyqt"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
```bash
brew tap videomorph-dev/videomorph "https://github.com/videomorph-dev/videomorph.git"
```
gives the error
```bash
Cloning into '/usr/local/Homebrew/Library/Taps/videomorph-dev/homebrew-videomorph'...
remote: Enumerating objects: 112, done.
remote: Counting objects: 100% (112/112), done.
remote: Compressing objects: 100% (105/105), done.
remote: Total 112 (delta 4), reused 59 (delta 0), pack-reused 0
Receiving objects: 100% (112/112), 3.06 MiB | 3.18 MiB/s, done.
Resolving deltas: 100% (4/4), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/videomorph-dev/homebrew-videomorph/videomorph.rb
videomorph: Unsupported special dependency :python3
Error: Cannot tap videomorph-dev/videomorph: invalid syntax in tap!
```
Accordingly to homebrew page, the python3 nomenclature is obsolete, the same for the :package nomenclature